### PR TITLE
Feature/sign up

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,6 +10,8 @@ import {
   useFonts,
   Kanit_400Regular,
   Kanit_400Regular_Italic,
+  Kanit_700Bold,
+  Kanit_700Bold_Italic,
   Kanit_800ExtraBold,
   Kanit_800ExtraBold_Italic,
 } from "@expo-google-fonts/kanit";
@@ -37,6 +39,8 @@ export default function App() {
   const [fontsLoaded] = useFonts({
     Kanit_400Regular,
     Kanit_400Regular_Italic,
+    Kanit_700Bold,
+    Kanit_700Bold_Italic,
     Kanit_800ExtraBold,
     Kanit_800ExtraBold_Italic,
   });

--- a/App.tsx
+++ b/App.tsx
@@ -1,10 +1,11 @@
 import "react-native-gesture-handler";
-import React, { useCallback, useEffect, useState } from "react";
-import { NavigationContainer } from "@react-navigation/native";
-import { StatusBar } from "expo-status-bar";
-import * as SplashScreen from "expo-splash-screen";
+import React from "react";
+import { StatusBar } from "react-native";
 import { ThemeProvider } from "styled-components/native";
-import { AppRoutes } from "./src/routes/app.routes";
+
+import { LogBox, View } from "react-native";
+import { AuthProvider } from "./src/shared/hooks/AuthContext";
+import { Routes } from "./src/routes";
 
 import {
   useFonts,
@@ -16,10 +17,6 @@ import {
   Kanit_800ExtraBold_Italic,
 } from "@expo-google-fonts/kanit";
 import DarkTheme from "./src/global/styles/DarkTheme";
-
-import { LogBox, View } from "react-native";
-import { AuthProvider } from "./src/shared/hooks/AuthContext";
-import { Routes } from "./src/routes";
 
 LogBox.ignoreLogs([
   "[react-native-gesture-handler] Seems like you're using an old API with gesture components, check out new Gestures system!",
@@ -51,7 +48,11 @@ export default function App() {
   return (
     <ThemeProvider theme={DarkTheme}>
       <AuthProvider>
-        <StatusBar style="auto" />
+        <StatusBar
+          barStyle="light-content"
+          backgroundColor="transparent"
+          translucent
+        />
         <Routes />
       </AuthProvider>
     </ThemeProvider>

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "17.0.2",
     "react-native": "0.68.2",
     "react-native-gesture-handler": "~2.2.0",
+    "react-native-iphone-x-helper": "^1.3.1",
     "react-native-responsive-fontsize": "^0.5.1",
     "react-native-safe-area-context": "4.2.4",
     "react-native-screens": "~3.11.1",

--- a/src/global/styles/DarkTheme.ts
+++ b/src/global/styles/DarkTheme.ts
@@ -32,6 +32,8 @@ export default {
   fonts: {
     regular: "Kanit_400Regular",
     regular_italic: "Kanit_400Regular_Italic",
+    bold: "Kanit_700Bold",
+    bold_italic: "Kanit_700Bold_Italic",
     black: "Kanit_800ExtraBold",
     black_italic: "Kanit_800ExtraBold_Italic",
   },

--- a/src/routes/signin.routes.tsx
+++ b/src/routes/signin.routes.tsx
@@ -8,8 +8,14 @@ const { Navigator, Screen } = createStackNavigator();
 
 export function SigninRoutes() {
   return (
-    <Navigator>
-      <Screen name="Login" component={RegisterAccountScreen} />
+    <Navigator
+      initialRouteName="Login"
+      screenOptions={{
+        headerShown: false,
+      }}
+    >
+      <Screen name="Login" component={Login} />
+      <Screen name="RegisterAccount" component={RegisterAccountScreen} />
     </Navigator>
   );
 }

--- a/src/routes/signin.routes.tsx
+++ b/src/routes/signin.routes.tsx
@@ -2,13 +2,14 @@ import React from "react";
 import { createStackNavigator } from "@react-navigation/stack";
 
 import Login from "../screens/Login";
+import RegisterAccountScreen from "../screens/RegisterAccount";
 
 const { Navigator, Screen } = createStackNavigator();
 
 export function SigninRoutes() {
   return (
     <Navigator>
-      <Screen name="Login" component={Login} />
+      <Screen name="Login" component={RegisterAccountScreen} />
     </Navigator>
   );
 }

--- a/src/routes/signin.routes.tsx
+++ b/src/routes/signin.routes.tsx
@@ -8,7 +8,7 @@ const { Navigator, Screen } = createStackNavigator();
 export function SigninRoutes() {
   return (
     <Navigator>
-      <Screen name="Logged Screen" component={Login} />
+      <Screen name="Login" component={Login} />
     </Navigator>
   );
 }

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -15,11 +15,14 @@ import { Button } from "../../shared/components/Button";
 import { Alert } from "react-native";
 import { useAuth } from "../../shared/hooks/AuthContext";
 import { AppError } from "../../shared/errors/AppError";
+import { useNavigation } from "@react-navigation/native";
 
 export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPasswrod] = useState("");
   const { signIn } = useAuth();
+
+  const navigation = useNavigation<any>();
 
   async function handleLogin() {
     try {
@@ -31,8 +34,8 @@ export default function Login() {
     }
   }
 
-  async function handleSignUp() {
-    Alert.alert("navigate to register screen");
+  async function handleRegisterAccount() {
+    navigation.navigate("RegisterAccount");
   }
 
   return (
@@ -64,7 +67,7 @@ export default function Login() {
         <Spacer />
         <Button title="Login" onPress={handleLogin} />
         <Spacer />
-        <Button title="Criar conta" onPress={handleSignUp} />
+        <Button title="Criar conta" onPress={handleRegisterAccount} />
       </LoginForm>
     </Container>
   );

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -19,7 +19,7 @@ import { AppError } from "../../shared/errors/AppError";
 export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPasswrod] = useState("");
-  const { signIn, signUp } = useAuth();
+  const { signIn } = useAuth();
 
   async function handleLogin() {
     try {
@@ -32,12 +32,7 @@ export default function Login() {
   }
 
   async function handleSignUp() {
-    try {
-      await signUp(email, password);
-    } catch (error) {
-      if (error instanceof AppError) return Alert.alert(error.message);
-      console.log(`unknown ERROR: ${error}`);
-    }
+    Alert.alert("navigate to register screen");
   }
 
   return (

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -19,20 +19,21 @@ import { AppError } from "../../shared/errors/AppError";
 export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPasswrod] = useState("");
-  const { signIn, googleSignIn } = useAuth();
+  const { signIn, signUp } = useAuth();
 
   async function handleLogin() {
     try {
       await signIn(email, password);
     } catch (error) {
-      if (error instanceof AppError) return Alert.alert(error.message);
+      if (error instanceof AppError)
+        return Alert.alert(`${error.message} - ${error.statusCode}`);
       console.log(`unknown ERROR: ${error}`);
     }
   }
 
-  async function handleGoogleLogin() {
+  async function handleSignUp() {
     try {
-      await googleSignIn();
+      await signUp(email, password);
     } catch (error) {
       if (error instanceof AppError) return Alert.alert(error.message);
       console.log(`unknown ERROR: ${error}`);
@@ -67,7 +68,8 @@ export default function Login() {
         </InputField>
         <Spacer />
         <Button title="Login" onPress={handleLogin} />
-        <Button title="Login com Google" onPress={handleGoogleLogin} />
+        <Spacer />
+        <Button title="Criar conta" onPress={handleSignUp} />
       </LoginForm>
     </Container>
   );

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -19,11 +19,20 @@ import { AppError } from "../../shared/errors/AppError";
 export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPasswrod] = useState("");
-  const { signIn } = useAuth();
+  const { signIn, googleSignIn } = useAuth();
 
   async function handleLogin() {
     try {
       await signIn(email, password);
+    } catch (error) {
+      if (error instanceof AppError) return Alert.alert(error.message);
+      console.log(`unknown ERROR: ${error}`);
+    }
+  }
+
+  async function handleGoogleLogin() {
+    try {
+      await googleSignIn();
     } catch (error) {
       if (error instanceof AppError) return Alert.alert(error.message);
       console.log(`unknown ERROR: ${error}`);
@@ -58,6 +67,7 @@ export default function Login() {
         </InputField>
         <Spacer />
         <Button title="Login" onPress={handleLogin} />
+        <Button title="Login com Google" onPress={handleGoogleLogin} />
       </LoginForm>
     </Container>
   );

--- a/src/screens/Login/styles.ts
+++ b/src/screens/Login/styles.ts
@@ -1,9 +1,5 @@
 import styled from "styled-components/native";
 
-export const TempText = styled.Text`
-  color: aqua;
-`;
-
 export const Container = styled.View`
   flex: 1;
   background-color: ${({ theme }) => theme.colors.background};

--- a/src/screens/Login/styles.ts
+++ b/src/screens/Login/styles.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components/native";
+import { getStatusBarHeight } from "react-native-iphone-x-helper";
 
 export const Container = styled.View`
   flex: 1;
@@ -10,7 +11,9 @@ export const LogoImage = styled.Image`
   height: 159px;
 `;
 
-export const LogoContainer = styled.View``;
+export const LogoContainer = styled.View`
+  margin-top: ${getStatusBarHeight() + 24}px;
+`;
 
 export const LoginForm = styled.View`
   flex-direction: column;

--- a/src/screens/RegisterAccount/index.tsx
+++ b/src/screens/RegisterAccount/index.tsx
@@ -1,11 +1,31 @@
 import React from "react";
+import { Button } from "../../shared/components/Button";
 import Input from "../../shared/components/Input";
 
-import { Container, InputField, InputLabel } from "./styles";
+import {
+  Container,
+  InputField,
+  InputLabel,
+  HeaderTitle,
+  HeaderText,
+  Header,
+  Footer,
+  FooterText,
+} from "./styles";
 
 export default function RegisterAccountScreen() {
   return (
     <Container>
+      <Header>
+        <HeaderTitle>Legal!</HeaderTitle>
+        <HeaderText>
+          Preencha seus dados que vamos criar uma nova conta pra você.
+        </HeaderText>
+      </Header>
+      <InputField>
+        <InputLabel>Seu nome:</InputLabel>
+        <Input name="name" placeholder="seu nome completo" value={""} />
+      </InputField>
       <InputField>
         <InputLabel>E-Mail:</InputLabel>
         <Input
@@ -13,9 +33,31 @@ export default function RegisterAccountScreen() {
           keyboardType="email-address"
           placeholder="email@address.com"
           value={""}
-          onChangeText={(text) => console.log(text)}
         />
       </InputField>
+      <InputField>
+        <InputLabel>Senha:</InputLabel>
+        <Input name="password" placeholder="senha segura" value={""} />
+      </InputField>
+      <InputField>
+        <InputLabel>Confirmação:</InputLabel>
+        <Input
+          name="passwordConfirm"
+          placeholder="confirme sua senha"
+          value={""}
+        />
+      </InputField>
+      <Footer>
+        <FooterText>
+          Ao clicar no botão abaixo você concorda com a nossa política de
+          privacidade.
+        </FooterText>
+        <FooterText>
+          Você deve confirmar seu endereço de e-mail para poder fazer login no
+          aplicativo.
+        </FooterText>
+        <Button title="Criar conta!" />
+      </Footer>
     </Container>
   );
 }

--- a/src/screens/RegisterAccount/index.tsx
+++ b/src/screens/RegisterAccount/index.tsx
@@ -1,6 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
+import { Alert } from "react-native";
 import { Button } from "../../shared/components/Button";
 import Input from "../../shared/components/Input";
+import { AppError } from "../../shared/errors/AppError";
+import { useAuth } from "../../shared/hooks/AuthContext";
 
 import {
   Container,
@@ -14,6 +17,25 @@ import {
 } from "./styles";
 
 export default function RegisterAccountScreen() {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirm, setPasswordConfirm] = useState("");
+
+  const { signUp } = useAuth();
+
+  async function handleSubmit() {
+    if (password !== passwordConfirm)
+      return Alert.alert("As senhas não batem.");
+
+    try {
+      await signUp(email, password);
+    } catch (error) {
+      if (error instanceof AppError) Alert.alert(error.message);
+      console.log(error);
+    }
+  }
+
   return (
     <Container>
       <Header>
@@ -24,7 +46,12 @@ export default function RegisterAccountScreen() {
       </Header>
       <InputField>
         <InputLabel>Seu nome:</InputLabel>
-        <Input name="name" placeholder="seu nome completo" value={""} />
+        <Input
+          name="name"
+          placeholder="seu nome completo"
+          value={name}
+          onChangeText={(text) => setName(text)}
+        />
       </InputField>
       <InputField>
         <InputLabel>E-Mail:</InputLabel>
@@ -32,19 +59,28 @@ export default function RegisterAccountScreen() {
           name="email"
           keyboardType="email-address"
           placeholder="email@address.com"
-          value={""}
+          value={email}
+          onChangeText={(text) => setEmail(text)}
         />
       </InputField>
       <InputField>
         <InputLabel>Senha:</InputLabel>
-        <Input name="password" placeholder="senha segura" value={""} />
+        <Input
+          name="password"
+          placeholder="senha segura"
+          value={password}
+          secureTextEntry={true}
+          onChangeText={(text) => setPassword(text)}
+        />
       </InputField>
       <InputField>
         <InputLabel>Confirmação:</InputLabel>
         <Input
           name="passwordConfirm"
+          secureTextEntry={true}
           placeholder="confirme sua senha"
-          value={""}
+          value={passwordConfirm}
+          onChangeText={(text) => setPasswordConfirm(text)}
         />
       </InputField>
       <Footer>
@@ -56,7 +92,7 @@ export default function RegisterAccountScreen() {
           Você deve confirmar seu endereço de e-mail para poder fazer login no
           aplicativo.
         </FooterText>
-        <Button title="Criar conta!" />
+        <Button title="Criar conta!" onPress={handleSubmit} />
       </Footer>
     </Container>
   );

--- a/src/screens/RegisterAccount/index.tsx
+++ b/src/screens/RegisterAccount/index.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import Input from "../../shared/components/Input";
+
+import { Container, InputField, InputLabel } from "./styles";
+
+export default function RegisterAccountScreen() {
+  return (
+    <Container>
+      <InputField>
+        <InputLabel>E-Mail:</InputLabel>
+        <Input
+          name="email"
+          keyboardType="email-address"
+          placeholder="email@address.com"
+          value={""}
+          onChangeText={(text) => console.log(text)}
+        />
+      </InputField>
+    </Container>
+  );
+}

--- a/src/screens/RegisterAccount/styles.ts
+++ b/src/screens/RegisterAccount/styles.ts
@@ -1,9 +1,50 @@
+import { RFValue } from "react-native-responsive-fontsize";
 import styled from "styled-components/native";
 
 export const Container = styled.View`
   flex: 1;
+  background-color: ${({ theme }) => theme.colors.background};
+  padding: 0 24px;
 `;
 
-export const InputField = styled.View``;
+export const InputLabel = styled.Text`
+  font-family: ${({ theme }) => theme.fonts.regular};
+  color: ${({ theme }) => theme.colors.text};
+  font-size: ${RFValue(14)}px;
+  margin-bottom: 4px;
+`;
 
-export const InputLabel = styled.Text``;
+export const InputField = styled.View`
+  width: 100%;
+  margin-top: 8px;
+  margin-bottom: 8px;
+`;
+
+export const Header = styled.View`
+  margin-top: 12px;
+  margin-bottom: 20px;
+`;
+
+export const HeaderTitle = styled.Text`
+  font-family: ${({ theme }) => theme.fonts.bold};
+  color: ${({ theme }) => theme.colors.text};
+  font-size: ${RFValue(30)}px;
+  margin-top: 12px;
+`;
+
+export const HeaderText = styled.Text`
+  font-family: ${({ theme }) => theme.fonts.bold};
+  color: ${({ theme }) => theme.colors.text};
+  font-size: ${RFValue(16)}px;
+  margin-top: 12px;
+`;
+
+export const Footer = styled.View``;
+
+export const FooterText = styled.Text`
+  font-family: ${({ theme }) => theme.fonts.regular};
+  color: ${({ theme }) => theme.colors.text};
+  font-size: ${RFValue(14)}px;
+  margin-top: 8px;
+  margin-bottom: 8px;
+`;

--- a/src/screens/RegisterAccount/styles.ts
+++ b/src/screens/RegisterAccount/styles.ts
@@ -1,3 +1,4 @@
+import { getStatusBarHeight } from "react-native-iphone-x-helper";
 import { RFValue } from "react-native-responsive-fontsize";
 import styled from "styled-components/native";
 
@@ -21,7 +22,7 @@ export const InputField = styled.View`
 `;
 
 export const Header = styled.View`
-  margin-top: 12px;
+  margin-top: ${getStatusBarHeight() + 24}px;
   margin-bottom: 20px;
 `;
 

--- a/src/screens/RegisterAccount/styles.ts
+++ b/src/screens/RegisterAccount/styles.ts
@@ -1,0 +1,9 @@
+import styled from "styled-components/native";
+
+export const Container = styled.View`
+  flex: 1;
+`;
+
+export const InputField = styled.View``;
+
+export const InputLabel = styled.Text``;

--- a/src/shared/hooks/AuthContext.tsx
+++ b/src/shared/hooks/AuthContext.tsx
@@ -19,6 +19,7 @@ interface IAuthContextData {
   session: AuthSession | undefined | null;
   signIn(email: string, password: string): Promise<void>;
   signOut(): Promise<void>;
+  googleSignIn(): Promise<void>;
 }
 
 const AuthContext = createContext({} as IAuthContextData);
@@ -38,6 +39,16 @@ function AuthProvider({ children }: AuthProviderProps) {
   async function signIn(email: string, password: string) {
     const { error, user } = await supabase.auth.signIn({ email, password });
 
+    if (error) {
+      throw new AppError(error.message, error.status);
+    }
+  }
+
+  async function googleSignIn() {
+    const { user, session, error } = await supabase.auth.signIn({
+      provider: "google",
+    });
+    console.log({ session, error });
     if (error) {
       throw new AppError(error.message, error.status);
     }
@@ -79,7 +90,7 @@ function AuthProvider({ children }: AuthProviderProps) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ session, signIn, signOut }}>
+    <AuthContext.Provider value={{ session, signIn, signOut, googleSignIn }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/shared/hooks/AuthContext.tsx
+++ b/src/shared/hooks/AuthContext.tsx
@@ -18,8 +18,8 @@ interface AuthProviderProps {
 interface IAuthContextData {
   session: AuthSession | undefined | null;
   signIn(email: string, password: string): Promise<void>;
+  signUp(email: string, password: string): Promise<void>;
   signOut(): Promise<void>;
-  googleSignIn(): Promise<void>;
 }
 
 const AuthContext = createContext({} as IAuthContextData);
@@ -44,17 +44,16 @@ function AuthProvider({ children }: AuthProviderProps) {
     }
   }
 
-  async function googleSignIn() {
-    const { user, session, error } = await supabase.auth.signIn({
-      provider: "google",
-    });
-    console.log({ session, error });
+  async function signUp(email: string, password: string) {
+    const { error, user } = await supabase.auth.signUp({ email, password });
+    console.log({ email, password, user });
+    if (!error && user) {
+      return Alert.alert("Check your email for the login link!");
+    }
     if (error) {
       throw new AppError(error.message, error.status);
     }
   }
-
-  //TODO: Implement Sign Up function
 
   useEffect(() => {
     try {
@@ -90,7 +89,7 @@ function AuthProvider({ children }: AuthProviderProps) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ session, signIn, signOut, googleSignIn }}>
+    <AuthContext.Provider value={{ session, signIn, signUp, signOut }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
- [ ]  check for existing e-email address before register with supabase auth

Decided to let this validation with supabase auth. E-mail confirmation is now turned off and now it will validate double e-mail address when a user is signing up.

- [ ]  **save user information in `profiles` table**

Will implement this when implement user profile screen.

---

Implemented supabase signUp() on AuthContext. User full name is not being saved. Should ask user to complete his information after login in for the first time.

**May 17**

Implemented [Register Account](https://www.notion.so/Register-Screen-55643f9ee71d422db10b8bca81be8262) screen. (1h)

**May 18**

Implemented supabase signUp in AuthContext. (0.5h)

**May 19**

Implemented user registration with supabase auth. (1.5h)