### PR TITLE
Fix/save user fullname

### DIFF
--- a/src/screens/RegisterAccount/index.tsx
+++ b/src/screens/RegisterAccount/index.tsx
@@ -29,7 +29,7 @@ export default function RegisterAccountScreen() {
       return Alert.alert("As senhas não batem.");
 
     try {
-      await signUp(email, password);
+      await signUp(email, password, name);
     } catch (error) {
       if (error instanceof AppError) Alert.alert(error.message);
     }

--- a/src/shared/hooks/AuthContext.tsx
+++ b/src/shared/hooks/AuthContext.tsx
@@ -66,6 +66,7 @@ function AuthProvider({ children }: AuthProviderProps) {
     if (insert_error) {
       throw new AppError(insert_error.message, 500);
     }
+    console.log({ data });
   }
 
   function getUser() {

--- a/src/shared/hooks/AuthContext.tsx
+++ b/src/shared/hooks/AuthContext.tsx
@@ -17,7 +17,7 @@ interface AuthProviderProps {
 interface IAuthContextData {
   session: AuthSession | undefined | null;
   signIn(email: string, password: string): Promise<void>;
-  signUp(email: string, password: string): Promise<void>;
+  signUp(email: string, password: string, name: string): Promise<void>;
   getUser(): User | null;
   signOut(): Promise<void>;
   user: User | null;
@@ -47,11 +47,24 @@ function AuthProvider({ children }: AuthProviderProps) {
     }
   }
 
-  async function signUp(email: string, password: string) {
+  async function signUp(email: string, password: string, name: string) {
     const { error, user } = await supabase.auth.signUp({ email, password });
 
     if (error) {
       throw new AppError(error.message, error.status);
+    }
+
+    const { data, error: insert_error } = await supabase
+      .from("profiles")
+      .insert([
+        {
+          id: user?.id,
+          avatar_url: "",
+          full_name: name,
+        },
+      ]);
+    if (insert_error) {
+      throw new AppError(insert_error.message, 500);
     }
   }
 


### PR DESCRIPTION
Updated `profiles` table on supabase. Fixed all tables relations to point to `profiles` table and not users anymore. Added active boolean filed in `profiles` table.

Updated AuthHook to handle insert new created users into profiles table.

- [ ]  TODO: maybe it will be better to do this by creating a trigger on back end database.

---

User info is being saved into profiles table. Got to better handle how to get user's full name without have to call back end.

It will be necessary to implement User entity to save user's information in a state on AuthHook.

Will merge this branch into master and start to implement user entity.