### PR TITLE
Feature/save user guesses

### DIFF
--- a/src/screens/GroupPlayerGuesses/index.tsx
+++ b/src/screens/GroupPlayerGuesses/index.tsx
@@ -47,12 +47,14 @@ export default function GroupPlayerGuesses() {
 
   //TODO: prevent leaving this screen without save to database
   const [hasChanged, setHasChanged] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   const [matches, setMatches] = useState<UserMatchGuess[]>([]);
 
   async function loadMatchGuesses() {
     const response = await getUserGuessesByGroupId(group.group_id!);
     setMatches(response);
+    setIsLoading(false);
   }
 
   useEffect(() => {
@@ -88,6 +90,8 @@ export default function GroupPlayerGuesses() {
   }
 
   async function handleSaveGuesses() {
+    setIsLoading(true);
+
     const filteredGuesses = matches.filter(
       (match) => match.away_team_score_guess || match.home_team_score_guess
     );
@@ -106,6 +110,8 @@ export default function GroupPlayerGuesses() {
     } catch (error) {
       Alert.alert("Algo errado salvando seus palpites");
       console.log(error);
+    } finally {
+      setIsLoading(false);
     }
   }
 
@@ -143,7 +149,12 @@ export default function GroupPlayerGuesses() {
       )}
 
       <Footer>
-        <Button title="Salvar" onPress={handleSaveGuesses} />
+        <Button
+          title="Salvar"
+          onPress={handleSaveGuesses}
+          loading={isLoading}
+          enabled={hasChanged}
+        />
       </Footer>
     </Container>
   );

--- a/src/screens/GroupPlayerGuesses/index.tsx
+++ b/src/screens/GroupPlayerGuesses/index.tsx
@@ -112,6 +112,7 @@ export default function GroupPlayerGuesses() {
       console.log(error);
     } finally {
       setIsLoading(false);
+      setHasChanged(false);
     }
   }
 

--- a/src/screens/GroupPlayerGuesses/index.tsx
+++ b/src/screens/GroupPlayerGuesses/index.tsx
@@ -61,6 +61,28 @@ export default function GroupPlayerGuesses() {
     loadMatchGuesses();
   }, []);
 
+  useEffect(
+    () =>
+      navigation.addListener("beforeRemove", (e) => {
+        if (!hasChanged) return;
+        e.preventDefault();
+
+        Alert.alert(
+          "Descartar alterações?",
+          "Você tem palpites modificados e não salvou ainda.",
+          [
+            { text: "Ficar e salvar", style: "cancel", onPress: () => {} },
+            {
+              text: "Descartar",
+              style: "destructive",
+              onPress: () => navigation.dispatch(e.data.action),
+            },
+          ]
+        );
+      }),
+    [navigation, hasChanged]
+  );
+
   function handleSelectGroup(index: number) {
     setSelectedGroupIndex(index);
   }
@@ -72,7 +94,6 @@ export default function GroupPlayerGuesses() {
 
   function updateGuess(matchId: string, homeValue: number, awayValue: number) {
     setHasChanged(true);
-    console.log(`Update Guess! ${matchId}: ${homeValue} : ${awayValue}`);
     const updated = matches.map((match) => {
       if (match.match_id === matchId)
         return {

--- a/src/screens/GroupPlayerGuesses/index.tsx
+++ b/src/screens/GroupPlayerGuesses/index.tsx
@@ -64,20 +64,31 @@ export default function GroupPlayerGuesses() {
     Alert.alert("salvando");
   }
 
-  const groupMatches = matches.filter(
+  let groupMatches = matches.filter(
     (m) =>
       m.cup_group === String.fromCharCode(97 + selectedGroupIndex).toUpperCase()
   );
 
-  function updateGuess(guessId: string, homeValue: number, awayValue: number) {
+  function updateGuess(matchId: string, homeValue: number, awayValue: number) {
     setHasChanged(true);
-    Alert.alert(`Update Guess! ${guessId}: ${homeValue} : ${awayValue}`);
+    console.log(`Update Guess! ${matchId}: ${homeValue} : ${awayValue}`);
     //TODO: implement matches array update
-    let matchesDict = Object.assign(
-      {},
-      ...groupMatches.map((m) => ({ [m.match_id]: m }))
+    const updated = matches.map((match) => {
+      if (match.match_id === matchId)
+        return {
+          ...match,
+          home_team_score_guess: homeValue,
+          away_team_score_guess: awayValue,
+        };
+
+      return match;
+    });
+    groupMatches = updated.filter(
+      (m) =>
+        m.cup_group ===
+        String.fromCharCode(97 + selectedGroupIndex).toUpperCase()
     );
-    console.log(matchesDict[guessId]);
+    setMatches(updated);
   }
 
   return (

--- a/src/screens/GroupPlayerGuesses/index.tsx
+++ b/src/screens/GroupPlayerGuesses/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigation, useRoute } from "@react-navigation/native";
-import { Alert, FlatList, StatusBar, View } from "react-native";
+import { Alert, StatusBar, View } from "react-native";
 import { useTheme } from "styled-components";
 import BackButton from "../../shared/components/BackButton";
 import {
@@ -21,6 +21,7 @@ import CupGroupSelector from "../../shared/components/CupGroupSelector";
 import MatchGuessInput from "../../shared/components/MatchGuessInput";
 import { Button } from "../../shared/components/Button";
 import { ScrollView } from "react-native-gesture-handler";
+import { useAuth } from "../../shared/hooks/AuthContext";
 
 interface Params {
   group: Group;
@@ -40,6 +41,7 @@ export default function GroupPlayerGuesses() {
   const theme = useTheme();
 
   const { getUserGuessesByGroupId, saveUserGuesses } = useGroup();
+  const { userId } = useAuth();
 
   const [selectedGroupIndex, setSelectedGroupIndex] = useState(0);
 
@@ -73,6 +75,8 @@ export default function GroupPlayerGuesses() {
       if (match.match_id === matchId)
         return {
           ...match,
+          group_id: group.group_id!,
+          user_id: userId,
           home_team_score_guess: homeValue ? homeValue : 0,
           away_team_score_guess: awayValue ? awayValue : 0,
         };

--- a/src/shared/components/Button/index.tsx
+++ b/src/shared/components/Button/index.tsx
@@ -29,7 +29,7 @@ export function Button({
       style={{ opacity: enabled === false || loading === true ? 0.5 : 1 }}
     >
       {loading ? (
-        <ActivityIndicator color={theme.colors.shape} />
+        <ActivityIndicator color={theme.colors.text} />
       ) : (
         <Title light={light}>{title}</Title>
       )}

--- a/src/shared/components/CupGroupSelector/index.tsx
+++ b/src/shared/components/CupGroupSelector/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { FlatList } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
 import { SelectButton } from "./SelectButton";
 import { Container, Title } from "./styles";
@@ -27,7 +26,6 @@ export default function CupGroupSelector({ onSelect }: CupGroupSelectorProps) {
     setSelectedIndex(index);
   }
 
-  //TODO: try to use ScrollVoiew instead of FlatList
   return (
     <Container>
       <Title>Filtrar partidas do grupo:</Title>

--- a/src/shared/components/MatchGuessInput/ScoreInput/index.tsx
+++ b/src/shared/components/MatchGuessInput/ScoreInput/index.tsx
@@ -1,15 +1,21 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { FontAwesome5 } from "@expo/vector-icons";
 
 import { Container, ScoreButton, ScoreInputBox } from "./styles";
 
 interface ScoreInputProps {
+  initialValue: number;
   updateValue(value: number): void;
 }
 
-export default function ScoreInput({ updateValue }: ScoreInputProps) {
-  const [scoreValue, setScoreValue] = React.useState("0");
+export default function ScoreInput({
+  updateValue,
+  initialValue,
+}: ScoreInputProps) {
+  const [scoreValue, setScoreValue] = useState(
+    String(initialValue ? initialValue : 0)
+  );
 
   function addScore() {
     updateValue(Number(scoreValue) + 1);

--- a/src/shared/components/MatchGuessInput/ScoreInput/index.tsx
+++ b/src/shared/components/MatchGuessInput/ScoreInput/index.tsx
@@ -16,8 +16,12 @@ export default function ScoreInput({
   const [scoreValue, setScoreValue] = useState(
     String(initialValue ? initialValue : 0)
   );
+  const [isZero, setIsZero] = useState(
+    initialValue || initialValue === 0 ? true : false
+  );
 
   function addScore() {
+    setIsZero(true);
     updateValue(Number(scoreValue) + 1);
     setScoreValue(String(Number(scoreValue) + 1));
   }
@@ -35,7 +39,7 @@ export default function ScoreInput({
         <FontAwesome5 name="minus-circle" size={24} color="#fff" />
       </ScoreButton>
       <ScoreInputBox
-        value={scoreValue}
+        value={isZero ? scoreValue : "--"}
         onChangeText={(text) => setScoreValue(text)}
         editable={false}
         selectTextOnFocus={false}

--- a/src/shared/components/MatchGuessInput/ScoreInput/index.tsx
+++ b/src/shared/components/MatchGuessInput/ScoreInput/index.tsx
@@ -37,7 +37,8 @@ export default function ScoreInput({
       <ScoreInputBox
         value={scoreValue}
         onChangeText={(text) => setScoreValue(text)}
-        keyboardType="numeric"
+        editable={false}
+        selectTextOnFocus={false}
       />
       <ScoreButton onPress={addScore}>
         <FontAwesome5 name="plus-circle" size={24} color="#fff" />

--- a/src/shared/components/MatchGuessInput/index.tsx
+++ b/src/shared/components/MatchGuessInput/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { UserMatchGuess } from "../../hooks/GroupContext";
 import ScoreInput from "./ScoreInput";
 import {

--- a/src/shared/components/MatchGuessInput/index.tsx
+++ b/src/shared/components/MatchGuessInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { UserMatchGuess } from "../../hooks/GroupContext";
 import ScoreInput from "./ScoreInput";
 import {

--- a/src/shared/components/MatchGuessInput/index.tsx
+++ b/src/shared/components/MatchGuessInput/index.tsx
@@ -13,7 +13,7 @@ import TeamFlag from "./TeamFlag";
 
 interface MatchGuessProps {
   matchData: UserMatchGuess;
-  onUpdate(guessId: string, homeValue: number, awayValue: number): void;
+  onUpdate(matchId: string, homeValue: number, awayValue: number): void;
 }
 
 export default function MatchGuessInput({
@@ -38,11 +38,13 @@ export default function MatchGuessInput({
       </TopWrapper>
       <BottonWrapper>
         <ScoreInput
+          initialValue={matchData.home_team_score_guess}
           updateValue={(value) =>
             onUpdate(matchData.match_id, value, matchData.away_team_score_guess)
           }
         />
         <ScoreInput
+          initialValue={matchData.away_team_score_guess}
           updateValue={(value) =>
             onUpdate(matchData.match_id, matchData.home_team_score_guess, value)
           }

--- a/src/shared/hooks/GroupContext.tsx
+++ b/src/shared/hooks/GroupContext.tsx
@@ -210,10 +210,24 @@ function GroupProvider({ children, userId }: GroupProviderProps) {
   }
 
   async function saveUserGuesses(guesses: UserGuess[]) {
-    // const {data,error} = await supabase.from('guesses')
-    //   .upsert(guesses)
-    //TODO: separete new guesses from registered guesses to save or update database
-    console.log({ guesses });
+    const newGuesses = guesses.filter((guess) => guess.guess_id === null);
+    if (newGuesses.length > 0) {
+      const insertData = newGuesses.map(({ guess_id, ...guess }) => guess);
+      const { data: newData, error: newDataError } = await supabase
+        .from("guesses")
+        .insert(insertData);
+      console.log({ newDataError });
+      if (newDataError) throw new AppError("Error while saving new guesses");
+      console.log({ newData });
+    }
+
+    const updateGuesses = guesses.filter((guess) => guess.guess_id !== null);
+    if (updateGuesses.length > 0) {
+      const { data, error } = await supabase
+        .from("guesses")
+        .upsert(updateGuesses);
+      if (error) throw new AppError("Error while updating guesses");
+    }
   }
 
   return (

--- a/src/shared/hooks/GroupContext.tsx
+++ b/src/shared/hooks/GroupContext.tsx
@@ -216,9 +216,7 @@ function GroupProvider({ children, userId }: GroupProviderProps) {
       const { data: newData, error: newDataError } = await supabase
         .from("guesses")
         .insert(insertData);
-      console.log({ newDataError });
       if (newDataError) throw new AppError("Error while saving new guesses");
-      console.log({ newData });
     }
 
     const updateGuesses = guesses.filter((guess) => guess.guess_id !== null);

--- a/src/shared/hooks/GroupContext.tsx
+++ b/src/shared/hooks/GroupContext.tsx
@@ -56,6 +56,15 @@ interface GroupProviderProps {
   userId: string;
 }
 
+interface UserGuess {
+  guess_id?: number;
+  match_id: string;
+  group_id: string;
+  user_id: string;
+  home_team_score: number;
+  away_team_score: number;
+}
+
 interface IGroupContextData {
   getUserGroups(): Promise<UserGroup[]>;
   getGroupUsers(groupId: string): Promise<User[]>;
@@ -64,6 +73,7 @@ interface IGroupContextData {
   getUserById(userId: string): Promise<User>;
   joinGroup(groupId: string): Promise<any>;
   getUserGuessesByGroupId(groupId: string): Promise<UserMatchGuess[]>;
+  saveUserGuesses(guesses: UserGuess[] | undefined): Promise<void>;
 }
 
 const GroupContext = createContext({} as IGroupContextData);
@@ -199,6 +209,13 @@ function GroupProvider({ children, userId }: GroupProviderProps) {
     return Promise.resolve(data);
   }
 
+  async function saveUserGuesses(guesses: UserGuess[]) {
+    // const {data,error} = await supabase.from('guesses')
+    //   .upsert(guesses)
+    //TODO: separete new guesses from registered guesses to save or update database
+    console.log({ guesses });
+  }
+
   return (
     <GroupContext.Provider
       value={{
@@ -209,6 +226,7 @@ function GroupProvider({ children, userId }: GroupProviderProps) {
         getUserById,
         joinGroup,
         getUserGuessesByGroupId,
+        saveUserGuesses,
       }}
     >
       {children}
@@ -220,4 +238,12 @@ function useGroup() {
   return useContext(GroupContext);
 }
 
-export { GroupProvider, useGroup, UserGroup, Group, User, UserMatchGuess };
+export {
+  GroupProvider,
+  useGroup,
+  UserGroup,
+  Group,
+  User,
+  UserMatchGuess,
+  UserGuess,
+};


### PR DESCRIPTION
`GroupPlayerGuesses` screen needed a list of matches with its respective guess. Implemented a database function to list all matches if user have saved a guess for that specific match in that specific group it will be listed.

**Implemented SQL query to list matches**

Implemented a back end SQL query as a PostgreSQL function in `supabase` back end to list all matches and its guesses. It will return all matches, if it has a guess registered it will be listed and if not, guess values will be null.

**Implemented functions to update guess values**

Implemented a function to handle guess updates by pressing increment or decrement buttons in score input component.

**Implemented save guesses to database**

As `upsert` function in `supabase` will need the primary key to be provided, guesses are being separated, new guesses from guesses already in database. New guesses are created using `insert` function, and guesses are updated using the `upsert` function.

**Implemented prevent going back without save**

Added a listener to prevent going back, pressing back or using hardware back button, without saving guesses to database.