### PR TITLE
Feature/group ranking

### DIFF
--- a/src/screens/GroupDashboard/index.tsx
+++ b/src/screens/GroupDashboard/index.tsx
@@ -94,7 +94,7 @@ export default function GroupDashboard() {
             <GroupKpiTitle>Acertos</GroupKpiTitle>
           </GroupKpiWrapper>
         </GroupKpiContainer>
-        <GroupRanking />
+        <GroupRanking groupId={group.group_id!} />
       </Content>
       <Footer>
         <Button

--- a/src/shared/components/GroupRanking/index.tsx
+++ b/src/shared/components/GroupRanking/index.tsx
@@ -20,6 +20,7 @@ export default function GroupRanking({ groupId }: GroupRankingProps) {
 
   async function loadGroupRanking() {
     const response = await getGroupRankingByGroupId(groupId);
+    console.log({ response });
   }
 
   useEffect(() => {

--- a/src/shared/components/GroupRanking/index.tsx
+++ b/src/shared/components/GroupRanking/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { FontAwesome5 } from "@expo/vector-icons";
 import RankingLine from "./RankingLine";
 
@@ -9,7 +9,10 @@ import {
   RankingTitle,
   RankingTitleWrapper,
 } from "./styles";
-import { useGroup } from "../../hooks/GroupContext";
+import {
+  useGroup,
+  GroupRanking as GroupRankingLine,
+} from "../../hooks/GroupContext";
 
 interface GroupRankingProps {
   groupId: string;
@@ -18,9 +21,11 @@ interface GroupRankingProps {
 export default function GroupRanking({ groupId }: GroupRankingProps) {
   const { getGroupRankingByGroupId } = useGroup();
 
+  const [groupRanking, setGroupRanking] = useState<GroupRankingLine[]>([]);
+
   async function loadGroupRanking() {
     const response = await getGroupRankingByGroupId(groupId);
-    console.log({ response });
+    setGroupRanking(response);
   }
 
   useEffect(() => {
@@ -39,34 +44,16 @@ export default function GroupRanking({ groupId }: GroupRankingProps) {
           <FontAwesome5 name="medal" color="#FFFFFF" size={16} />
         </IconsWrapper>
       </RankingHeader>
-      <RankingLine
-        name="Thiago"
-        points={135}
-        position={1}
-        bonus={5}
-        guesses={5}
-      />
-      <RankingLine
-        name="Felipe"
-        points={35}
-        position={2}
-        bonus={15}
-        guesses={5}
-      />
-      <RankingLine
-        name="Thiago"
-        points={35}
-        position={3}
-        bonus={5}
-        guesses={5}
-      />
-      <RankingLine
-        name="Thiago"
-        points={35}
-        position={4}
-        bonus={5}
-        guesses={5}
-      />
+      {groupRanking.map((g, i) => (
+        <RankingLine
+          name={g.full_name}
+          points={g.total_points}
+          position={i + 1}
+          bonus={g.total_bonus}
+          guesses={g.exact_matches}
+          key={g.user_id}
+        />
+      ))}
     </Container>
   );
 }

--- a/src/shared/components/GroupRanking/index.tsx
+++ b/src/shared/components/GroupRanking/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { FontAwesome5 } from "@expo/vector-icons";
 import RankingLine from "./RankingLine";
 
@@ -9,8 +9,23 @@ import {
   RankingTitle,
   RankingTitleWrapper,
 } from "./styles";
+import { useGroup } from "../../hooks/GroupContext";
 
-export default function GroupRanking() {
+interface GroupRankingProps {
+  groupId: string;
+}
+
+export default function GroupRanking({ groupId }: GroupRankingProps) {
+  const { getGroupRankingByGroupId } = useGroup();
+
+  async function loadGroupRanking() {
+    const response = await getGroupRankingByGroupId(groupId);
+  }
+
+  useEffect(() => {
+    loadGroupRanking();
+  }, []);
+
   return (
     <Container>
       <RankingHeader>

--- a/src/shared/hooks/GroupContext.tsx
+++ b/src/shared/hooks/GroupContext.tsx
@@ -66,11 +66,13 @@ interface UserGuess {
 }
 
 interface GroupRanking {
-  position: number;
-  user: User;
-  user_points: number;
-  user_exact_matches: number;
-  user_bonus_points: number;
+  exact_matches: number;
+  full_name: string;
+  group_id: string;
+  name: string;
+  total_bonus: number;
+  total_points: number;
+  user_id: string;
 }
 
 interface IGroupContextData {
@@ -82,7 +84,7 @@ interface IGroupContextData {
   getUserById(userId: string): Promise<User>;
   joinGroup(groupId: string): Promise<any>;
   getUserGuessesByGroupId(groupId: string): Promise<UserMatchGuess[]>;
-  getGroupRankingByGroupId(groupId: string): Promise<void>;
+  getGroupRankingByGroupId(groupId: string): Promise<GroupRanking[]>;
   saveUserGuesses(guesses: UserGuess[] | undefined): Promise<void>;
   removeUserFromGroup(userId: string, groupId: string): Promise<void>;
 }
@@ -249,14 +251,14 @@ function GroupProvider({ children, userId }: GroupProviderProps) {
   }
 
   async function getGroupRankingByGroupId(groupId: string) {
-    const { data, error } = await supabase.rpc("group_match_guesses", {
-      param_group_id: groupId,
-    });
+    const { data, error } = await supabase
+      .from("group_ranking")
+      .select("*")
+      .eq("group_id", groupId);
 
-    console.log({ error });
     if (error) throw new AppError(`ERROR while getting group ranking`);
 
-    console.log(data);
+    return Promise.resolve(data);
   }
 
   async function saveUserGuesses(guesses: UserGuess[]) {

--- a/src/shared/hooks/GroupContext.tsx
+++ b/src/shared/hooks/GroupContext.tsx
@@ -65,6 +65,14 @@ interface UserGuess {
   away_team_score: number;
 }
 
+interface GroupRanking {
+  position: number;
+  user: User;
+  user_points: number;
+  user_exact_matches: number;
+  user_bonus_points: number;
+}
+
 interface IGroupContextData {
   getUserGroups(): Promise<UserGroup[]>;
   getGroupUsers(groupId: string): Promise<User[]>;
@@ -74,6 +82,7 @@ interface IGroupContextData {
   getUserById(userId: string): Promise<User>;
   joinGroup(groupId: string): Promise<any>;
   getUserGuessesByGroupId(groupId: string): Promise<UserMatchGuess[]>;
+  getGroupRankingByGroupId(groupId: string): Promise<void>;
   saveUserGuesses(guesses: UserGuess[] | undefined): Promise<void>;
   removeUserFromGroup(userId: string, groupId: string): Promise<void>;
 }
@@ -239,6 +248,17 @@ function GroupProvider({ children, userId }: GroupProviderProps) {
     return Promise.resolve(data);
   }
 
+  async function getGroupRankingByGroupId(groupId: string) {
+    const { data, error } = await supabase.rpc("group_match_guesses", {
+      param_group_id: groupId,
+    });
+
+    console.log({ error });
+    if (error) throw new AppError(`ERROR while getting group ranking`);
+
+    console.log(data);
+  }
+
   async function saveUserGuesses(guesses: UserGuess[]) {
     const newGuesses = guesses.filter((guess) => guess.guess_id === null);
     if (newGuesses.length > 0) {
@@ -279,6 +299,7 @@ function GroupProvider({ children, userId }: GroupProviderProps) {
         getUserById,
         joinGroup,
         getUserGuessesByGroupId,
+        getGroupRankingByGroupId,
         saveUserGuesses,
         removeUserFromGroup,
       }}

--- a/src/shared/hooks/GroupContext.tsx
+++ b/src/shared/hooks/GroupContext.tsx
@@ -323,4 +323,5 @@ export {
   User,
   UserMatchGuess,
   UserGuess,
+  GroupRanking,
 };


### PR DESCRIPTION
Updated `GroupRanking` component to reflect database data.

Implemented a `VIEW` to list a group players points and display it ordered by points.

How to use:
Use the `group_ranking` view as a regular table.
Should always specify a `group_id` to filter ranking for a specific group.

```typescript
    const { data, error } = await supabase
      .from("group_ranking")
      .select("*")
      .eq("group_id", groupId);
```
