### PR TITLE
Fix/prevent going back

### DIFF
--- a/src/screens/ConfirmationScreen/index.tsx
+++ b/src/screens/ConfirmationScreen/index.tsx
@@ -1,6 +1,10 @@
-import { useNavigation, useRoute } from "@react-navigation/native";
-import React from "react";
-import { StatusBar } from "react-native";
+import {
+  CommonActions,
+  useNavigation,
+  useRoute,
+} from "@react-navigation/native";
+import React, { useEffect } from "react";
+import { Alert, StatusBar } from "react-native";
 import { useTheme } from "styled-components";
 import { Button } from "../../shared/components/Button";
 
@@ -33,6 +37,28 @@ export default function ConfirmationScreen() {
   const theme = useTheme();
   const navigation = useNavigation();
 
+  useEffect(
+    () =>
+      navigation.addListener("beforeRemove", (e) => {
+        e.preventDefault();
+      }),
+    [navigation]
+  );
+
+  function handleGoBack() {
+    console.log("cliquei!");
+    navigation.dispatch((state) => {
+      // Remove the home route from the stack
+      const routes = state.routes.filter((r) => r.name === "Dashboard");
+
+      return CommonActions.reset({
+        ...state,
+        routes,
+        index: 0,
+      });
+    });
+  }
+
   return (
     <Container>
       <StatusBar
@@ -53,10 +79,7 @@ export default function ConfirmationScreen() {
         </ImageWrapper>
       </Content>
       <Footer>
-        <Button
-          title="Ok"
-          onPress={() => navigation.navigate(nextScreen as never)}
-        />
+        <Button title="Ok" onPress={handleGoBack} />
       </Footer>
     </Container>
   );

--- a/src/screens/ConfirmationScreen/index.tsx
+++ b/src/screens/ConfirmationScreen/index.tsx
@@ -3,7 +3,7 @@ import {
   useNavigation,
   useRoute,
 } from "@react-navigation/native";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { Alert, StatusBar } from "react-native";
 import { useTheme } from "styled-components";
 import { Button } from "../../shared/components/Button";
@@ -26,12 +26,11 @@ interface ConfirmationScreenProps {
   title: string;
   message: string;
   instructions: string;
-  nextScreen: string;
 }
 
 export default function ConfirmationScreen() {
   const route = useRoute();
-  const { title, message, instructions, nextScreen } =
+  const { title, message, instructions } =
     route.params as ConfirmationScreenProps;
 
   const theme = useTheme();
@@ -40,23 +39,17 @@ export default function ConfirmationScreen() {
   useEffect(
     () =>
       navigation.addListener("beforeRemove", (e) => {
+        if (e.data.action.type !== "GO_BACK") {
+          navigation.dispatch(e.data.action);
+          return;
+        }
         e.preventDefault();
       }),
     [navigation]
   );
 
   function handleGoBack() {
-    console.log("cliquei!");
-    navigation.dispatch((state) => {
-      // Remove the home route from the stack
-      const routes = state.routes.filter((r) => r.name === "Dashboard");
-
-      return CommonActions.reset({
-        ...state,
-        routes,
-        index: 0,
-      });
-    });
+    navigation.navigate("Dashboard" as never);
   }
 
   return (

--- a/src/screens/GroupPlayerGuesses/index.tsx
+++ b/src/screens/GroupPlayerGuesses/index.tsx
@@ -45,7 +45,6 @@ export default function GroupPlayerGuesses() {
 
   const [selectedGroupIndex, setSelectedGroupIndex] = useState(0);
 
-  //TODO: prevent leaving this screen without save to database
   const [hasChanged, setHasChanged] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 


### PR DESCRIPTION
Implemented a verification to prevent user from going back to new group screen or join group screen from `ConfirmationScreen`.

- Implemented a listener that voids user to go back when back button is pressed or swiped back on screen.
- Dispatch navigation action when user press ok button.