### PR TITLE
reload user guesses after save guesses to database to load guess_id 

### DIFF
--- a/src/screens/GroupPlayerGuesses/index.tsx
+++ b/src/screens/GroupPlayerGuesses/index.tsx
@@ -131,6 +131,7 @@ export default function GroupPlayerGuesses() {
     } finally {
       setIsLoading(false);
       setHasChanged(false);
+      await loadMatchGuesses();
     }
   }
 


### PR DESCRIPTION
Reload user guesses after save guesses to database to load guess_id information and prevent saving multiple guesses for each match.
---
When user click on save button on user group guesses screen the guesses were being saved to database but the array with guesses were never updated, so if user clicks on save again it will save two guesses for the same match.